### PR TITLE
Feature/delete group button

### DIFF
--- a/app/controllers/Users.scala
+++ b/app/controllers/Users.scala
@@ -178,8 +178,8 @@ trait UsersContext extends Controller {
         b <- svc.groupManager.process(a)
       } yield b)
       .fold(e => BadRequest(e), r => {
-        svc.store.writeContext(r)
-        Ok(r)
+        svc.store.writeContext(r)(eJ.user)
+        Ok(eJ.user.writes(r))
       })
     )
   }

--- a/app/engine/service/GroupManager.scala
+++ b/app/engine/service/GroupManager.scala
@@ -21,7 +21,10 @@ trait GroupManager extends ServiceCore[InternalGroupCmd, P.GroupCmd] {
         case _ => "Duplicate Group Name. Names must be unique"
       }
       case P.RemoveGroup(g) => context.groups.exists(_.id == g) match {
-        case true => RemoveGroup(context, context.groups.filter(_.id == g).head)
+        case true => context.groups.length match {
+          case 1 => "Cannot Remove your last group for now!"
+          case _ =>  RemoveGroup(context, context.groups.filter(_.id == g).head)
+        }
         case false => "Unknown Group cannot be removed"
       }
       case P.AddChannelToGroup(id, c) =>

--- a/app/views/groups.scala.html
+++ b/app/views/groups.scala.html
@@ -36,9 +36,10 @@
         <ul class="list-group" id="groupList">
             <li class="list-group-item" id="groupItemList">
                 @for(g <- user.groups) {
-                    <li>
+                    <li id=@g.id.value>
                     @g.label
                     <!-- TODO add an update group button -->
+                        <button class="deleteGroupBtn btn btn-default">Delete</button>
                     </li>
                 }
                 <button id="newGroupButton" type="button" class="btn btn-primary btn-lg" data-toggle="modal" data-target="#createGroupModal">

--- a/public/javascripts/groupModal.js
+++ b/public/javascripts/groupModal.js
@@ -11,4 +11,16 @@ $(document).ready(function(){
             type: "POST"
         })
     });
+
+    $(".deleteGroupBtn").click(function(){
+        var userId = $.cookie("user");
+        var groupId = $(this).parent().attr("id");
+
+        $.ajax("users/"+userId+"/groups/"+groupId, {
+            success: function(data) {
+               $("#"+groupId).remove();
+            },
+            type: "DELETE"
+        })
+    })
 });


### PR DESCRIPTION
This pull allows users to remove groups with the click of a button. It also ensures they always have at least one group present.
